### PR TITLE
Ignore PDF files in CBZ and ZAB archives

### DIFF
--- a/Sources/Shared/Toolkit/Media Type/MediaTypeSniffer.swift
+++ b/Sources/Shared/Toolkit/Media Type/MediaTypeSniffer.swift
@@ -311,6 +311,11 @@ public extension MediaType {
         "asx", "bio", "m3u", "m3u8", "pla", "pls", "smil", "vlc", "wpl", "xspf", "zpl"
     ]
     
+    // For archives containing PDF files.
+    private static let ignoredFileExtensions = [
+        "pdf"
+    ]
+    
     /// Sniffs a simple archive-based format, like Comic Book Archive or Zipped Audio Book.
     /// Reference: https://wiki.mobileread.com/wiki/CBR_and_CBZ
     private static func sniffArchive(context: MediaTypeSnifferContext) -> MediaType? {
@@ -324,7 +329,11 @@ public extension MediaType {
         if context.contentAsArchive != nil {
             func isIgnored(_ url: URL) -> Bool {
                 let filename = url.lastPathComponent
-                return url.hasDirectoryPath || filename.hasPrefix(".") || filename == "Thumbs.db"
+                let fileExtension = url.pathExtension.lowercased()
+                return url.hasDirectoryPath ||
+                       filename.hasPrefix(".") ||
+                       filename == "Thumbs.db" ||
+                       ignoredFileExtensions.contains(fileExtension)
             }
 
             func archiveContainsOnlyExtensions(_ fileExtensions: [String]) -> Bool {

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -58,11 +58,15 @@ public final class AudioParser: PublicationParser {
     private func ignores(_ link: Link) -> Bool {
         let url = URL(fileURLWithPath: link.href)
         let filename = url.lastPathComponent
+        let fileExtension = url.pathExtension.lowercased()
+        // // For archives containing PDF files.
+        let ignoredFileExtensions = ["pdf"]
         let allowedExtensions = ["asx", "bio", "m3u", "m3u8", "pla", "pls", "smil", "txt", "vlc", "wpl", "xspf", "zpl"]
         
-        return allowedExtensions.contains(url.pathExtension.lowercased())
-            || filename.hasPrefix(".")
-            || filename == "Thumbs.db"
+        return allowedExtensions.contains(fileExtension) ||
+               ignoredFileExtensions.contains(fileExtension) ||
+               filename.hasPrefix(".") ||
+               filename == "Thumbs.db"
     }
     
     @available(*, unavailable, message: "Not supported for `AudioParser`")


### PR DESCRIPTION
In some cases the CBZ and ZAB archives may contain PDF files, to avoid opening errors we just ignore PDF files for now.