### PR TITLE
fix: ignore .jpg files in audio archives

### DIFF
--- a/Sources/Shared/Toolkit/Media Type/MediaTypeSniffer.swift
+++ b/Sources/Shared/Toolkit/Media Type/MediaTypeSniffer.swift
@@ -313,7 +313,7 @@ public extension MediaType {
     
     // For archives containing PDF files.
     private static let ignoredFileExtensions = [
-        "pdf"
+        "pdf", "jpg"
     ]
     
     /// Sniffs a simple archive-based format, like Comic Book Archive or Zipped Audio Book.

--- a/Sources/Streamer/Parser/Audio/AudioParser.swift
+++ b/Sources/Streamer/Parser/Audio/AudioParser.swift
@@ -60,7 +60,7 @@ public final class AudioParser: PublicationParser {
         let filename = url.lastPathComponent
         let fileExtension = url.pathExtension.lowercased()
         // // For archives containing PDF files.
-        let ignoredFileExtensions = ["pdf"]
+        let ignoredFileExtensions = ["pdf", "jpg"]
         let allowedExtensions = ["asx", "bio", "m3u", "m3u8", "pla", "pls", "smil", "txt", "vlc", "wpl", "xspf", "zpl"]
         
         return allowedExtensions.contains(fileExtension) ||


### PR DESCRIPTION
In some cases, the audio archives may contain .jpg files, to fix audio playing issue we should ignore them